### PR TITLE
upgrade-runtime-version

### DIFF
--- a/re.sonny.OhMySVG.json
+++ b/re.sonny.OhMySVG.json
@@ -1,7 +1,7 @@
 {
   "id": "re.sonny.OhMySVG",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "re.sonny.OhMySVG",
   "finish-args": [


### PR DESCRIPTION
Version 47 is deprecated, skipped 48.